### PR TITLE
Update ServerVersion in manifest.json

### DIFF
--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -11,7 +11,7 @@
     }
   ],
   "Website": "",
-  "ServerVersion": "*",
+  "ServerVersion": "2026.02.19-1a311a592",
   "Dependencies": {},
   "OptionalDependencies": {},
   "DisabledByDefault": false,


### PR DESCRIPTION
Fixing the “One or more plugins are targeting an older server version” warning on world startup by replacing the wildcard version with the actual server version. 

Reported by this user #7767059 -> https://www.curseforge.com/hytale/mods/hyrestart/comments 